### PR TITLE
fixes https://github.com/RobertWeinmeister/dokuwiki-mermaid/issues/54

### DIFF
--- a/action.php
+++ b/action.php
@@ -157,7 +157,17 @@ class action_plugin_mermaid extends \dokuwiki\Extension\ActionPlugin
     private function pageIncludesMermaid(): bool {
         // true if the mermaid tag is used
         // the include plugin can hide this fact, so we need a separate check for it
-        $wikiText = rawWiki(getID());
+        global $ACT;
+        global $TEXT;
+        if ('preview'==$ACT) {
+            $wikiText = $TEXT;
+        } else {
+            $wikiText = rawWiki(getID());
+        }
+
+        if ('edit'==$ACT) {
+            return false;
+        }
         if (str_contains($wikiText, '<mermaid') || str_contains($wikiText, '{{page>') || str_contains($wikiText, '{{section>') || str_contains($wikiText, '{{namespace>') || str_contains($wikiText, '{{tagtopic>')) {
             return true;
         }

--- a/action.php
+++ b/action.php
@@ -162,6 +162,9 @@ class action_plugin_mermaid extends \dokuwiki\Extension\ActionPlugin
             return true;
         }
 
+        global $ACT;
+        if ('preview'==$ACT) return true;
+
         return false;
     }
 

--- a/action.php
+++ b/action.php
@@ -172,9 +172,6 @@ class action_plugin_mermaid extends \dokuwiki\Extension\ActionPlugin
             return true;
         }
 
-        global $ACT;
-        if ('preview'==$ACT) return true;
-
         return false;
     }
 


### PR DESCRIPTION
This is my proposed fix...

mermaid.js will be included in the preview, if there is mermaid code to preview, regardless of what was in the last revision, or not included when there is no preview (when simply loading the edit form)